### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/2015-08/SDN/container_demo/src/iface/iface.go
+++ b/2015-08/SDN/container_demo/src/iface/iface.go
@@ -59,7 +59,7 @@ func SetAddr(iface string, cidr string) {
 	}
 }
 
-/* Return true if @iface name exists */
+/* Exists returns true if @iface name exists */
 func Exists(iface string) bool {
 	_, err := netlink.LinkByName(iface)
 	return err == nil

--- a/2015-08/SDN/container_demo/src/route/route.go
+++ b/2015-08/SDN/container_demo/src/route/route.go
@@ -38,7 +38,7 @@ func List(ifs ...string) {
         }
 }
 
-/* Check if route @src -> @dst exists with the same destination netmask as @r */
+/* Exists checks if route @src -> @dst exists with the same destination netmask as @r */
 func Exists(r *netlink.Route) bool {
 	/* FIXME: see bug of RouteList mentioned in above List() command */
 	routes, err := netlink.RouteList(nil, 0)


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?